### PR TITLE
Introduce library structure.

### DIFF
--- a/ap.hpp
+++ b/ap.hpp
@@ -1,0 +1,6 @@
+#ifndef DEOHAYER_AP_AP_HPP
+#define DEOHAYER_AP_AP_HPP
+
+#include "int.hpp"
+
+#endif

--- a/array.hpp
+++ b/array.hpp
@@ -1,0 +1,39 @@
+#ifndef DEOHAYER_AP_ARRAY_HPP
+#define DEOHAYER_AP_ARRAY_HPP
+
+#include "core.hpp"
+#include <memory>   // std::unique_ptr
+#include <stdlib.h> // malloc, realloc, free
+
+namespace ap
+{
+namespace library
+{
+
+template <typename T>
+using array = std::unique_ptr<T[], void (*)(void*)>;
+
+template <typename T>
+array<T> array_alloc(index_t count)
+{
+    return array<T>{reinterpret_cast<T*>(std::malloc(sizeof(T) * count)), &std::free};
+}
+
+template <typename T>
+array<T>& array_realloc(array<T>& arr, index_t count)
+{
+    T* raw_ptr = arr.release();
+    arr.reset(reinterpret_cast<T*>(std::realloc(raw_ptr, sizeof(T) * count)));
+    return arr;
+}
+
+template <typename T>
+array<T> array_null()
+{
+    return array<T>{reinterpret_cast<T*>(NULL), &std::free};
+}
+
+} // namespace library
+} // namespace ap
+
+#endif

--- a/asm.cpp
+++ b/asm.cpp
@@ -1,0 +1,414 @@
+#ifndef DEOHAYER_AP_ASM_CPP
+#define DEOHAYER_AP_ASM_CPP 1
+#endif
+#if (DEOHAYER_AP_ASM_CPP == 1) == defined(AP_USE_SOURCES)
+
+#include "asm.hpp"
+
+namespace ap
+{
+namespace library
+{
+
+cmpres asm_cmp(const rregister& left, const rregister& right)
+{
+    for (index_t i = left.size; i > 0;)
+    {
+        --i;
+        if (left.words[i] > right.words[i])
+        {
+            return cmpres{cmpres::greater, i + 1};
+        }
+        else if (left.words[i] < right.words[i])
+        {
+            return cmpres{cmpres::less, i + 1};
+        }
+    }
+    return cmpres{cmpres::equal, 0};
+}
+
+index_t asm_trim(const word_t* const words, index_t size)
+{
+    const word_t* const _words = words - 1;
+    for (index_t i = size; i > 0; --i)
+    {
+        if (_words[i] != 0)
+        {
+            return i;
+        }
+    }
+    return 0;
+}
+
+void asm_fill(wregister& inout, word_t word)
+{
+    inout.size = inout.capacity;
+    for (index_t i = 0; i < inout.size; ++i)
+    {
+        inout.words[i] = word;
+    }
+}
+
+void asm_cp(const rregister& in, wregister& out)
+{
+    out.size = in.size;
+    std::memcpy(out.words, in.words, in.size * word_traits::bytes);
+}
+
+void asm_twos(const rregister& in, wregister& out)
+{
+    out.size = out.capacity;
+    dword_t carry = 1;
+    index_t i = 0;
+    for (; i < in.size; ++i)
+    {
+        carry += static_cast<word_t>(~in.words[i]);
+        out.words[i] = carry;
+        carry >>= word_traits::bits;
+    }
+    for (; i < out.capacity; ++i)
+    {
+        carry += word_traits::ones;
+        out.words[i] = carry;
+        carry >>= word_traits::bits;
+    }
+}
+
+dword_t asm_add(const rregister& left, const rregister& right, wregister& out)
+{
+    dword_t carry = 0;
+    index_t i = 0;
+
+    for (; i < right.size; ++i)
+    {
+        carry += left.words[i];
+        carry += right.words[i];
+        out.words[i] = carry;
+        carry >>= word_traits::bits;
+    }
+
+    for (; i < left.size; ++i)
+    {
+        carry += left.words[i];
+        out.words[i] = carry;
+        carry >>= word_traits::bits;
+    }
+
+    if (out.capacity > left.size)
+    {
+        out.words[i] = carry;
+        ++i;
+        if (carry != 0)
+        {
+            carry = 0;
+        }
+    }
+
+    out.size = i;
+    return carry;
+}
+
+void asm_sub(const rregister& left, const rregister& right, wregister& out)
+{
+    static constexpr index_t borrow_shift = dword_traits::bits - 1;
+    dword_t borrow = 0;
+    index_t i = 0;
+
+    for (; i < right.size; ++i)
+    {
+        borrow = left.words[i] - borrow;
+        borrow -= right.words[i];
+        out.words[i] = borrow;
+        borrow >>= borrow_shift;
+    }
+
+    for (; i < left.size; ++i)
+    {
+        borrow = left.words[i] - borrow;
+        out.words[i] = borrow;
+        borrow >>= borrow_shift;
+    }
+
+    out.size = i;
+}
+
+dword_t asm_mul(const rregister& left, dword_t right, wregister& out)
+{
+    const index_t stop_index = MIN(left.size, out.capacity);
+    dword_t carry = 0;
+    index_t i = 0;
+
+    for (; i < out.size; ++i)
+    {
+        carry += out.words[i];
+        carry += right * left.words[i];
+        out.words[i] = carry;
+        carry >>= word_traits::bits;
+    }
+
+    for (; i < stop_index; ++i)
+    {
+        carry += right * left.words[i];
+        out.words[i] = carry;
+        carry >>= word_traits::bits;
+    }
+
+    if (out.capacity > stop_index)
+    {
+        out.words[i] = carry;
+        ++i;
+        if (carry != 0)
+        {
+            carry = 0;
+        }
+    }
+
+    out.size = i;
+    return carry;
+}
+
+dword_t asm_mul(const rregister& left, const rregister& right, wregister& out)
+{
+    wregister out_tmp = out;
+    dword_t carry = 0;
+    out_tmp.size = 0;
+    for (index_t i = 0; i < right.size; ++i)
+    {
+        carry += asm_mul(left, right.words[i], out_tmp);
+        ++out_tmp.words;
+        --out_tmp.capacity;
+        --out_tmp.size;
+    }
+    out.size = out_tmp.size + right.size;
+    return carry;
+}
+
+void asm_div(const rregister& left, dword_t right, wregister& quo, wregister& rem)
+{
+    index_t i = left.size - 1;
+    dword_t carry;
+
+    if (left.words[i] < right)
+    {
+        quo.size = i;
+        carry = left.words[i];
+    }
+    else
+    {
+        quo.size = left.size;
+        carry = left.words[i] % right;
+        quo.words[i] = left.words[i] / right;
+    }
+
+    while (i > 0)
+    {
+        --i;
+        carry <<= word_traits::bits;
+        carry |= left.words[i];
+        quo.words[i] = carry / right;
+        carry %= right;
+    }
+    rem.words[0] = carry;
+    rem.size = 1;
+}
+
+void asm_div(const rregister& left, const rregister& right, wregister& quo, wregister& rem)
+{
+    static constexpr index_t borrow_shift = dword_traits::bits - 1;
+    static constexpr dword_t base = dword_t{word_traits::ones} + 1;
+    const dword_t normalizer = ((base / 2) / right.words[right.size - 1]) + ((base / 2) % right.words[right.size - 1] != 0);
+
+    // Normalize dividend (left).
+    auto nleft_digits = array_alloc<word_t>(left.size + 1);
+    wregister nleft{nleft_digits.get(), index_t(left.size + 1), 0, false};
+    asm_mul(left, normalizer, nleft);
+    dword_t u2 = 0;
+    dword_t u1 = 0;
+    dword_t u0 = 0;
+
+    // Normalize divisor (right).
+    auto nright_digits = array_alloc<word_t>(right.size);
+    wregister nright{nright_digits.get(), right.size, 0, false};
+    asm_mul(right, normalizer, nright);
+    const dword_t v1 = nright.words[nright.size - 1];
+    const dword_t v0 = nright.words[nright.size - 2];
+
+    // Single division step context.
+
+    // Difference in size of normalized operands. "+ 1" because u2 acts as extra most significant word of rem.
+    const index_t size_diff = (nleft.size - nright.size);
+    index_t j = 0;      // Number of single-word divisions.
+    index_t i = 0;      // Iterator for single-word divisions.
+    dword_t q = 0;      // Single-word quotient, written to rem at the end of iteration.
+    dword_t r = 0;      // Single word remainder, used in q approximation.
+    dword_t carry = 0;  // Used in multiply-subtract part of single-word division.
+    dword_t borrow = 0; // Used in multiply-subtract part of single-word division.
+
+    for (size_t j = size_diff; j > 0;)
+    {
+        --j;
+        i = j + nright.size;
+        u2 = nleft.words[i];
+        u1 = nleft.words[i - 1];
+        u0 = nleft.words[i - 2];
+        q = u2;
+        q <<= word_traits::bits;
+        q += u1;
+        r = q % v1;
+        q /= v1;
+        if (q == base || q * v0 > (base * r + u0))
+        {
+            --q;
+            r += v1;
+            if (r < base)
+            {
+                if (q == base || q * v0 > (base * r + u0))
+                {
+                    --q;
+                    r += v1;
+                }
+            }
+        }
+        i = j;
+        borrow = 0;
+        carry = 0;
+        for (index_t k = 0; k < right.size; ++k, ++i)
+        {
+            borrow = nleft.words[i] - borrow;
+            carry += nright.words[k] * q;
+            borrow -= static_cast<word_t>(carry);
+            nleft.words[i] = borrow;
+            borrow >>= borrow_shift;
+            carry >>= (word_traits::bits);
+        }
+        borrow += carry;
+        if (borrow != 0)
+        {
+            if (nleft.words[i] >= borrow)
+            {
+                nleft.words[i] -= borrow;
+            }
+            else // unlikely
+            {
+                --q;
+                i = j;
+                carry = 0;
+                for (size_t k = 0; k < right.size; ++k, ++i)
+                {
+                    carry += nleft.words[i];
+                    carry += nright.words[k];
+                    nleft.words[i] = carry;
+                    carry >>= word_traits::bits;
+                }
+                nleft.words[i] += carry;
+                nleft.words[i] -= borrow;
+            }
+        }
+        quo.words[j] = q;
+    }
+    quo.size = size_diff;
+    nleft.size = i;
+    if (nleft.size != 0)
+    {
+        asm_div(rregister(nleft), normalizer, rem, nright);
+    }
+}
+
+using bit_op_t = word_t (*)(word_t, word_t);
+
+template <bit_op_t op>
+void asm_bit(const rregister& left, const rregister& right, wregister& out)
+{
+    index_t i = 0;
+    for (; i < right.size; ++i)
+    {
+        out.words[i] = op(left.words[i], right.words[i]);
+    }
+    for (; i < left.size; ++i)
+    {
+        out.words[i] = op(left.words[i], 0);
+    }
+    out.size = left.size;
+}
+
+static inline word_t bit_or(word_t a, word_t b)
+{
+    return a | b;
+};
+
+void asm_or(const rregister& left, const rregister& right, wregister& out)
+{
+    asm_bit<bit_or>(left, right, out);
+}
+
+static inline word_t bit_xor(word_t a, word_t b)
+{
+    return a ^ b;
+};
+
+void asm_xor(const rregister& left, const rregister& right, wregister& out)
+{
+    asm_bit<bit_xor>(left, right, out);
+}
+
+static inline word_t bit_and(word_t a, word_t b)
+{
+    return a & b;
+};
+
+void asm_and(const rregister& left, const rregister& right, wregister& out)
+{
+    asm_bit<bit_and>(left, right, out);
+}
+
+void asm_not(const rregister& in, wregister& out)
+{
+    for (index_t i = 0; i < in.size; ++i)
+    {
+        out.words[i] = ~in.words[i];
+    }
+    for (index_t i = in.size; i < out.capacity; ++i)
+    {
+        out.words[i] = word_traits::ones;
+    }
+    out.size = out.capacity;
+}
+
+void asm_rsh(const rregister& in, index_t shift, wregister& out)
+{
+    dword_t dword = in.words[0];
+    for (index_t i = 1; i < in.size; ++i)
+    {
+        dword |= (dword_t{in.words[i]} << word_traits::bits);
+        out.words[i - 1] = (dword >> shift);
+        dword >>= word_traits::bits;
+    }
+    out.words[in.size - 1] = (dword >> shift);
+    out.size = in.size;
+}
+
+void asm_lsh(const rregister& in, index_t shift, wregister& out)
+{
+    // First word will be overwritten if in and out refer to the same number.
+    word_t first = (in.words[0] << shift);
+    dword_t dword = in.words[0];
+    shift = word_traits::bits - shift;
+    for (index_t i = 1; i < in.size; ++i)
+    {
+        dword |= (dword_t{in.words[i]} << word_traits::bits);
+        out.words[i] = (dword >> shift);
+        dword >>= word_traits::bits;
+    }
+    out.words[0] = first;
+    out.size = in.size;
+    if (out.capacity > in.size)
+    {
+        out.words[in.size] = (dword >> shift);
+        ++out.size;
+    }
+}
+
+} // namespace library
+} // namespace ap
+
+#endif

--- a/asm.hpp
+++ b/asm.hpp
@@ -1,0 +1,230 @@
+#ifndef DEOHAYER_AP_ASM_HPP
+#define DEOHAYER_AP_ASM_HPP
+
+#define FLEX_DEBUG_LEVEL 255
+#include "array.hpp"
+#include "core.hpp"
+#include <cstring>
+
+//
+// All of the functions below represent bare algorithms. They work with unsigned multiprecision values.
+// However, they put strict limitations on their operands. Each operation always yields correct two's complement
+// bit pattern. Since values are unsigned, it is up to the upper layers, how this bit pattern is treated.
+//
+
+namespace ap
+{
+namespace library
+{
+
+struct cmpres
+{
+    int result;
+    index_t size;
+
+    cmpres() : cmpres(0, 0) {}
+    cmpres(int _result, index_t _size) : result(_result), size(_size) {}
+
+    cmpres(const cmpres& other) = default;
+    cmpres& operator=(const cmpres& other) = default;
+
+    cmpres(cmpres&& other) = default;
+    cmpres& operator=(cmpres&& other) = default;
+
+    enum
+    {
+        less = -1,
+        greater = -less,
+        equal = 0
+    };
+};
+
+// Arithmetically compare two registers of equal size.
+// Return: Result of comparison and size of the unequal part.
+// Change: None.
+// Preconditions:
+// left.size == right.size
+ap_linkage cmpres asm_cmp(const rregister& left, const rregister& right);
+
+// Adjust size to ensure that words[0, size) contains no leading zeros.
+// Return: Adjusted size.
+// Change: None.
+// Preconditions: None
+ap_linkage index_t asm_trim(const word_t* const words, index_t size);
+
+// Adjust size of inout to ensure that inout.words[0, inout.size) contains no leading zeros.
+// Return: None.
+// Change:
+// inout.size adjusted accordingly.
+// Preconditions: None.
+template <typename _Words>
+void asm_trim(dregister<_Words>& inout)
+{
+    inout.size = asm_trim(inout.words, inout.size);
+}
+
+// Fill inout with word to full capacity.
+// Return: None.
+// Change:
+// inout.size = inout.capacity.
+// inout.words is filled with word.
+// Preconditions: None.
+ap_linkage void asm_fill(wregister& inout, word_t word);
+
+// Copy words from in to out.
+// Return: None.
+// Change:
+// out.size = in.size.
+// out.words[0, out.size) is word-wise equal to in.words[0, in.size).
+// Preconditions:
+// in.size in [0, out.capacity].
+ap_linkage void asm_cp(const rregister& in, wregister& out);
+
+// Write two's complement of in to out.
+// Return: None.
+// Change:
+// out.size = out.capacity.
+// out.words[0, out.capacity) contains untrimmed two's complement of in.
+// Preconditions:
+// in.size in [0, out.capacity].
+ap_linkage void asm_twos(const rregister& in, wregister& out);
+
+// Word-wise wrapping addition of left and right.
+// Return: Carry (1 if overflow, 0 otherwise).
+// Change:
+// out.size = MIN(left.size + 1, out.capacity).
+// out.words contains untrimmed wrapped two's complement pattern of the result of operation.
+// Preconditions:
+// right.size in [0, left.size].
+// left.size in [0, out.capacity].
+ap_linkage dword_t asm_add(const rregister& left, const rregister& right, wregister& out);
+
+// Word-wise subtraction of right from left.
+// Return: None.
+// Change:
+// out.size = left.size.
+// out.words contains untrimmed two's complement pattern of the result of operation.
+// Preconditions:
+// right is arithmetically less than left.
+// left.size in [0, out.capacity].
+ap_linkage void asm_sub(const rregister& left, const rregister& right, wregister& out);
+
+// Word-wise wrapping long-short multiplication left by right with addition to out (long multiplication step).
+// Return: Carry of the operation, if overflow occured.
+// Change:
+// out.size = MIN(left.size + 1, out.capacity).
+// out.words contains untrimmed wrapped two's complement pattern of (left * right + out).
+// Preconditions:
+// right in [0, word_traits::ones]
+// right.size in [0, left.size].
+// left.size in [0, out.capacity].
+ap_linkage dword_t asm_mul(const rregister& left, dword_t right, wregister& out);
+
+// Word-wise wrapping long-long multiplication left by right.
+// Return: Carry of the operation, if overflow occured.
+// Case of an obvious overflow shall be tracked by the caller (left.size + right.size > out.capacity + 1).
+// Change:
+// out.size = MIN(left.size + right.size, out.capacity).
+// out.words contains untrimmed wrapped two's complement pattern of (left * right).
+// Preconditions:
+// Trimmed operands.
+// &left != &out
+// &right != &out
+// right.size > 0.
+// right.size in [0, left.size].
+// left.size in [0, out.capacity].
+ap_linkage dword_t asm_mul(const rregister& left, const rregister& right, wregister& out);
+
+// Long-short division left by right.
+// Return: None.
+// Change:
+// quo.size = left.size.
+// quo.words contains untrimmed two's complement pattern of (left / right).
+// rem.size = 1.
+// rem.words contains untrimmed two's complement pattern of (left % right).
+// Preconditions:
+// right in [1, word_traits::ones].
+// left.size in [0, out.capacity].
+ap_linkage void asm_div(const rregister& left, dword_t right, wregister& quo, wregister& rem);
+
+// Long-long division left by right.
+// Return: None.
+// Change:
+// quo.size = left.size + 1 - right.size.
+// quo.words contains untrimmed two's complement pattern of (left / right).
+// rem.size = right.size.
+// rem.words contains untrimmed two's complement pattern of (left % right).
+// Preconditions:
+// rem.capacity >= right.size.
+// right.size in [2, left.size].
+// left.size in [2, quo.capacity].
+ap_linkage void asm_div(const rregister& left, const rregister& right, wregister& quo, wregister& rem);
+
+// Word-wise OR operation.
+// Return: None.
+// Change:
+// out.size = left.size.
+// out.words contains untrimmed two's complement pattern of (left | right).
+// Preconditions:
+// right.size in [0, left.size].
+// left.size in [0, out.capacity].
+ap_linkage void asm_or(const rregister& left, const rregister& right, wregister& out);
+
+// Word-wise XOR operation.
+// Return: None.
+// Change:
+// out.size = left.size.
+// out.words contains untrimmed two's complement pattern of (left ^ right).
+// Preconditions:
+// right.size in [0, left.size].
+// left.size in [0, out.capacity].
+ap_linkage void asm_xor(const rregister& left, const rregister& right, wregister& out);
+
+// Word-wise AND operation.
+// Return: None.
+// Change:
+// out.size = left.size.
+// out.words contains untrimmed two's complement pattern of (left & right).
+// Preconditions:
+// right.size in [0, left.size].
+// left.size in [0, out.capacity].
+ap_linkage void asm_and(const rregister& left, const rregister& right, wregister& out);
+
+// Word-wise NOT operation.
+// Return: None.
+// Change:
+// out.size = out.capacity.
+// out.words contains untrimmed two's complement pattern of ~in, with extra words filled as all-ones.
+// Preconditions:
+// in.size in [0, out.capacity].
+ap_linkage void asm_not(const rregister& in, wregister& out);
+
+// Word-wise right shift.
+// Return: None.
+// Change:
+// out.size = in.size.
+// out.words contains untrimmed two's complement pattern of (in >> shift).
+// Preconditions:
+// shift in [1, word_traits::bits).
+// in.size in [1, out.capacity].
+ap_linkage void asm_rsh(const rregister& in, index_t shift, wregister& out);
+
+// Word-wise left shift.
+// Return: None.
+// Change:
+// out.size = MIN(in.size + 1, out.capacity).
+// out.words contains untrimmed wrapped two's complement pattern of (in << shift).
+// Preconditions:
+// shift in [1, word_traits::bits).
+// in.size in [1, out.capacity].
+ap_linkage void asm_lsh(const rregister& in, index_t shift, wregister& out);
+
+} // namespace library
+} // namespace ap
+
+#ifndef AP_USE_SOURCES
+#define DEOHAYER_AP_ASM_CPP 0
+#include "asm.cpp"
+#endif
+
+#endif

--- a/config.hpp
+++ b/config.hpp
@@ -1,0 +1,76 @@
+#ifndef DEOHAYER_AP_CONFIG_HPP
+#define DEOHAYER_AP_CONFIG_HPP
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Userspace configuration.
+
+// Core types.
+
+#ifndef AP_WORD
+#define AP_WORD unsigned
+#endif
+
+#ifndef AP_DWORD
+#define AP_DWORD unsigned long long
+#endif
+
+#ifndef AP_SIZE
+#define AP_SIZE unsigned
+#endif
+
+// Runtime assertion.
+
+#ifndef AP_USE_ASSERT
+#define AP_NO_ASSERT
+#endif
+
+// Linkage.
+
+#ifndef AP_USE_SOURCES
+#define AP_NO_USE_SOURCES
+#endif
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Internal configuration.
+
+// Core types.
+
+#ifndef AP_WORD_SIZE
+#define AP_WORD_SIZE sizeof(AP_WORD)
+#endif
+
+#ifndef AP_DWORD_SIZE
+#define AP_DWORD_SIZE sizeof(AP_DWORD)
+#endif
+
+static_assert(AP_WORD_SIZE * 2 == AP_DWORD_SIZE);
+static_assert(sizeof(AP_WORD) == AP_WORD_SIZE);
+static_assert(sizeof(AP_DWORD) == AP_DWORD_SIZE);
+
+// Debug.
+
+#ifndef AP_NO_ASSERT
+#include <exception>
+#define AP_ASSERT(cond, ...)                                         \
+    do                                                               \
+    {                                                                \
+        if (!(cond))                                                 \
+        {                                                            \
+            char buf[1024];                                          \
+            sprintf(buf, __VA_ARGS__);                               \
+            throw std::runtime_error{static_cast<const char*>(buf)}; \
+        }                                                            \
+    } while (0)
+#else
+#define AP_ASSERT(cond, ...)
+#endif
+
+// Linkage.
+
+#ifndef AP_NO_USE_SOURCES
+#define ap_linkage extern
+#else
+#define ap_linkage static inline
+#endif
+
+#endif

--- a/core.hpp
+++ b/core.hpp
@@ -1,0 +1,203 @@
+#ifndef DEOHAYER_AP_CORE_HPP
+#define DEOHAYER_AP_CORE_HPP
+
+#include "config.hpp"
+#include <climits> // CHAR_BIT
+
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+
+namespace ap
+{
+namespace library
+{
+
+using word_t = AP_WORD;
+using dword_t = AP_DWORD;
+using index_t = AP_SIZE;
+
+template <typename T>
+struct integer_traits
+{
+    static constexpr std::size_t bytes = sizeof(T);
+    static constexpr std::size_t bits = bytes * CHAR_BIT;
+    static constexpr T zeros = 0;
+    static constexpr T ones = ~T{zeros};
+    static constexpr T nmsb = ones >> 1;
+    static constexpr T msb = ~nmsb;
+};
+
+using word_traits = integer_traits<word_t>;
+using dword_traits = integer_traits<dword_t>;
+using index_traits = integer_traits<index_t>;
+
+// Flag register.
+struct fregister
+{
+protected:
+    index_t value;
+
+public:
+    constexpr fregister() : fregister(0) {}
+    constexpr fregister(index_t _value) : value(_value) {}
+
+    constexpr fregister(const fregister& other) = default;
+    fregister& operator=(const fregister& other) = default;
+
+    constexpr fregister(fregister&& other) = default;
+    fregister& operator=(fregister&& other) = default;
+
+    constexpr explicit operator index_t() const
+    {
+        return this->value;
+    }
+
+    constexpr fregister operator|(fregister other) const
+    {
+        return fregister{this->value | other.value};
+    }
+
+    constexpr fregister operator&(fregister other) const
+    {
+        return fregister{this->value & other.value};
+    }
+
+    constexpr fregister operator^(fregister other) const
+    {
+        return fregister{this->value ^ other.value};
+    }
+
+    fregister& operator|=(fregister other)
+    {
+        this->value |= other.value;
+        return (*this);
+    }
+
+    fregister& operator&=(fregister other)
+    {
+        this->value &= other.value;
+        return (*this);
+    }
+
+    fregister& operator^=(fregister other)
+    {
+        this->value ^= other.value;
+        return (*this);
+    }
+
+    constexpr fregister operator~() const
+    {
+        return fregister{~(this->value)};
+    }
+
+    constexpr bool operator==(const fregister other) const
+    {
+        return this->value == other.value;
+    }
+
+    constexpr bool operator!=(const fregister other) const
+    {
+        return this->value != other.value;
+    }
+
+    fregister& flip(fregister other)
+    {
+        return (*this) ^= other;
+    }
+
+    fregister& set(fregister other)
+    {
+        return (*this) |= other;
+    }
+
+    fregister& unset(fregister other)
+    {
+        return (*this) &= ~other;
+    }
+
+    constexpr bool has_any(fregister flags) const
+    {
+        return ((*this) & flags).value > 0;
+    }
+
+    constexpr bool has_all(fregister flags) const
+    {
+        return ((*this) & flags) == flags;
+    }
+
+    void clear()
+    {
+        this->value = 0;
+    }
+
+    constexpr bool empty() const
+    {
+        return this->value == 0;
+    }
+
+    enum
+    {
+        noneflag = 0,
+        infinity = 1 << 1,
+        overflow = 1 << 2,
+        wrapping = 1 << 3,
+        signflip = 1 << 4
+    };
+};
+
+// Data register.
+template <typename _Words>
+struct dregister
+{
+public:
+    _Words words;
+    index_t capacity : index_traits::bits / 2 - 1;
+    index_t size : index_traits::bits / 2 - 1;
+    index_t sign : 1;
+
+private:
+    index_t __unused : 1;
+
+public:
+    dregister() : dregister(nullptr, 0, 0, false) {}
+
+    dregister(_Words _words, index_t _capacity, index_t _size, bool _sign)
+        : words(_words),
+          capacity(_capacity),
+          size(_size),
+          sign(_sign) {}
+
+    dregister(const dregister&) = default;
+    dregister& operator=(const dregister&) = default;
+
+    dregister(dregister&&) = default;
+    dregister& operator=(dregister&&) = default;
+
+    explicit operator dregister<const word_t*>() const
+    {
+        return dregister<const word_t*>{
+            this->words,
+            this->capacity,
+            this->size,
+            this->sign};
+    }
+
+    bool has_msb() const
+    {
+        return (this->capacity == this->size) && (this->words[this->capacity - 1] >> (word_traits::bits - 1));
+    }
+
+    void clear_msb()
+    {
+        this->words[this->capacity - 1] &= (word_traits::ones >> 1);
+    }
+};
+
+using rregister = dregister<const word_t*>;
+using wregister = dregister<word_t*>;
+
+} // namespace library
+} // namespace ap
+
+#endif

--- a/int.hpp
+++ b/int.hpp
@@ -1,0 +1,6 @@
+#ifndef DEOHAYER_AP_INT_HPP
+#define DEOHAYER_AP_INT_HPP
+
+#include "int_alg.hpp"
+
+#endif

--- a/int_alg.cpp
+++ b/int_alg.cpp
@@ -1,0 +1,221 @@
+#ifndef DEOHAYER_AP_INT_ALG_CPP
+#define DEOHAYER_AP_INT_ALG_CPP 1
+#endif
+#if (DEOHAYER_AP_INT_ALG_CPP == 1) == defined(AP_USE_SOURCES)
+
+#include "asm.hpp"
+#include <utility>
+
+namespace ap
+{
+namespace library
+{
+
+#define WRAP(rreg, wreg)                    \
+    do                                      \
+    {                                       \
+        if (wreg.capacity < rreg.size)      \
+        {                                   \
+            rreg.size = wreg.capacity;      \
+            flags.set(fregister::wrapping); \
+        }                                   \
+    } while (false)
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Unsigned algorithms definitions
+
+std::string uint_tstr(const rregister& in, const index_t& base, const char* digits)
+{
+    std::string result;
+    return result;
+}
+
+fregister uint_fstr(wregister& out, const std::string& str, const index_t& base, const char* digits)
+{
+    fregister flags;
+    return flags;
+}
+
+cmpres uint_cmp(const rregister& left, const rregister& right)
+{
+    cmpres result;
+    return result;
+}
+
+void uint_ucp(const rregister& in, wregister& out)
+{
+}
+
+fregister uint_scp(rregister in, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister uint_add(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister uint_sub(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister uint_mul(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister uint_div(rregister left, rregister right, wregister& quo, wregister& rem)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister uint_or(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister uint_xor(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister uint_and(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister uint_not(rregister in, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister uint_rsh(rregister in, index_t shift, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister uint_lsh(rregister in, index_t shift, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Signed algorithms definitions
+
+std::string sint_tstr(const rregister& in, const index_t& base, const char* digits)
+{
+    std::string result;
+    return result;
+}
+
+fregister sint_fstr(wregister& out, const std::string& str, const index_t& base, const char* digits)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_stou(rregister in, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_utos(rregister in, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+cmpres sint_cmp(const rregister& left, const rregister& right)
+{
+    cmpres result;
+    return result;
+}
+
+void sint_ucp(const rregister& in, wregister& out)
+{
+}
+
+fregister sint_scp(rregister in, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_add(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_sub(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_mul(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_div(rregister left, rregister right, wregister& quo, wregister& rem)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_or(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_xor(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_and(rregister left, rregister right, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_not(rregister in, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_rsh(rregister in, index_t shift, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+fregister sint_lsh(rregister in, index_t shift, wregister& out)
+{
+    fregister flags;
+    return flags;
+}
+
+} // namespace library
+} // namespace ap
+
+#endif

--- a/int_alg.hpp
+++ b/int_alg.hpp
@@ -1,0 +1,91 @@
+#ifndef DEOHAYER_AP_INT_ALG_HPP
+#define DEOHAYER_AP_INT_ALG_HPP
+
+#include "asm.hpp"
+#include <string>
+#include <utility>
+
+namespace ap
+{
+namespace library
+{
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Unsigned algorithms declarations
+
+ap_linkage std::string uint_tstr(const rregister& in, const index_t& base, const char* digits);
+
+ap_linkage fregister uint_fstr(wregister& out, const std::string& str, const index_t& base, const char* digits);
+
+ap_linkage cmpres uint_cmp(const rregister& left, const rregister& right);
+
+ap_linkage void uint_ucp(const rregister& in, wregister& out);
+
+ap_linkage fregister uint_scp(rregister in, wregister& out);
+
+ap_linkage fregister uint_add(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister uint_sub(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister uint_mul(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister uint_div(rregister left, rregister right, wregister& quo, wregister& rem);
+
+ap_linkage fregister uint_or(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister uint_xor(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister uint_and(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister uint_not(rregister in, wregister& out);
+
+ap_linkage fregister uint_rsh(rregister in, index_t shift, wregister& out);
+
+ap_linkage fregister uint_lsh(rregister in, index_t shift, wregister& out);
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Signed algorithms declarations
+
+ap_linkage std::string sint_tstr(const rregister& in, const index_t& base, const char* digits);
+
+ap_linkage fregister sint_fstr(wregister& out, const std::string& str, const index_t& base, const char* digits);
+
+ap_linkage fregister sint_stou(rregister in, wregister& out);
+
+ap_linkage fregister sint_utos(rregister in, wregister& out);
+
+ap_linkage cmpres sint_cmp(const rregister& left, const rregister& right);
+
+ap_linkage void sint_ucp(const rregister& in, wregister& out);
+
+ap_linkage fregister sint_scp(rregister in, wregister& out);
+
+ap_linkage fregister sint_add(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister sint_sub(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister sint_mul(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister sint_div(rregister left, rregister right, wregister& quo, wregister& rem);
+
+ap_linkage fregister sint_or(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister sint_xor(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister sint_and(rregister left, rregister right, wregister& out);
+
+ap_linkage fregister sint_not(rregister in, wregister& out);
+
+ap_linkage fregister sint_rsh(rregister in, index_t shift, wregister& out);
+
+ap_linkage fregister sint_lsh(rregister in, index_t shift, wregister& out);
+
+} // namespace library
+} // namespace ap
+
+#ifndef AP_USE_SOURCES
+#define DEOHAYER_AP_INT_ALG_CPP 0
+#include "int_alg.cpp"
+#endif
+
+#endif


### PR DESCRIPTION
Library is one-level, to avoid adding include paths, using relative paths:
ap.hpp      - Supposed to be included by library user.
array.hpp   - Handles array allocation via malloc.
asm.*       - Core arithmetic algorithms with strict limitations on operands.
config.hpp  - Build options. Visually split in two parts to see available options.
core.hpp    - Core definitions and types, used accross the library.
int_alg.*   - Integer interface functions, accept any operands.
int.hpp     - Integer class itself.

By default library is header-only, *.cpp are included into *.hpp, and functions
are declared as "static inline". AP_USE_SOURCES must be defined to be able to compile
*.cpp files separately.